### PR TITLE
Make local NameTextWrap nullable, and only set if non-null

### DIFF
--- a/PlayerTrack.Plugin/Handler/NameplateHandler.cs
+++ b/PlayerTrack.Plugin/Handler/NameplateHandler.cs
@@ -106,7 +106,8 @@ public static class NameplateHandler
                     handler.FreeCompanyTagParts.RightQuote = nameplate.FreeCompanyRightQuote;
                 }
 
-                handler.NameParts.TextWrap = nameplate.NameTextWrap;
+                if (nameplate.NameTextWrap is not null)
+                    handler.NameParts.TextWrap = nameplate.NameTextWrap;
             }
         }
     }

--- a/PlayerTrack.Plugin/Models/Models/Player/PlayerNameplate.cs
+++ b/PlayerTrack.Plugin/Models/Models/Player/PlayerNameplate.cs
@@ -16,7 +16,7 @@ public class PlayerNameplate
 
     public SeString? TitleRightQuote { get; set; }
 
-    public (SeString, SeString) NameTextWrap { get; set; }
+    public (SeString, SeString)? NameTextWrap { get; set; }
 
     public SeString? FreeCompanyLeftQuote { get; set; }
 


### PR DESCRIPTION
Make `NameTextWrap` nullable to match other fields, and only set on nameplate handler when it's non-null. This fixes a bug where an invalid SeString tuple of `(null, null)` was set on the handler, which breaks processing in Dalamud.