### PR TITLE
Add configurable chat channel for notifications

### DIFF
--- a/PlayerTrack.Plugin/Extensions/ChatGuiExtension.cs
+++ b/PlayerTrack.Plugin/Extensions/ChatGuiExtension.cs
@@ -1,9 +1,9 @@
-﻿using System.Collections.Generic;
-using System.Linq;
+using System.Collections.Generic;
 using Dalamud.Game.Text;
 using Dalamud.Game.Text.SeStringHandling;
 using Dalamud.Game.Text.SeStringHandling.Payloads;
 using Dalamud.Plugin.Services;
+using PlayerTrack.Domain;
 
 namespace PlayerTrack.Extensions;
 
@@ -13,16 +13,22 @@ namespace PlayerTrack.Extensions;
 public static class ChatGuiExtensions
 {
     /// <summary>
-    /// Print message with plugin name to notice channel.
+    /// Print message with plugin name to the configured chat channel
+    /// (defaults to <see cref="XivChatType.Notice"/>).
     /// </summary>
     /// <param name="value">chat gui service.</param>
     /// <param name="payloads">list of payloads.</param>
     public static void PluginPrintNotice(this IChatGui value, IEnumerable<Payload> payloads)
     {
+        var config = ServiceContext.ConfigService.GetConfig();
+        var type = config.UseCustomChatChannel
+            ? config.CustomChatChannel
+            : XivChatType.Notice;
+
         value.Print(new XivChatEntry
         {
             Message = BuildSeString(Plugin.PluginInterface.InternalName, payloads),
-            Type = XivChatType.Notice,
+            Type = type,
         });
     }
 

--- a/PlayerTrack.Plugin/Models/Models/Config/PluginConfig.cs
+++ b/PlayerTrack.Plugin/Models/Models/Config/PluginConfig.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using Dalamud.Game.Text;
 using Dalamud.Interface;
 using Newtonsoft.Json;
 using PlayerTrack.Data;
@@ -122,6 +123,10 @@ public class PluginConfig : IPluginConfig
     public bool OnlyShowWindowWhenLoggedIn { get; set; }
 
     public NoCategoryPlacement NoCategoryPlacement { get; set; } = NoCategoryPlacement.Bottom;
+
+    public bool UseCustomChatChannel { get; set; }
+
+    public XivChatType CustomChatChannel { get; set; } = XivChatType.Notice;
 
     public TrackingLocationConfig GetTrackingLocationConfig(LocationType locType) => locType switch
     {

--- a/PlayerTrack.Plugin/Resource/Language.Designer.cs
+++ b/PlayerTrack.Plugin/Resource/Language.Designer.cs
@@ -400,7 +400,25 @@ namespace PlayerTrack.Resource {
                 return ResourceManager.GetString("CategorySpecificSetting", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   Looks up a localized string similar to Chat.
+        /// </summary>
+        internal static string Chat {
+            get {
+                return ResourceManager.GetString("Chat", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Chat Channel.
+        /// </summary>
+        internal static string ChatChannel {
+            get {
+                return ResourceManager.GetString("ChatChannel", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to Close Player.
         /// </summary>
@@ -2668,7 +2686,16 @@ namespace PlayerTrack.Resource {
                 return ResourceManager.GetString("Upgrade", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   Looks up a localized string similar to Use Custom Chat Channel.
+        /// </summary>
+        internal static string UseCustomChatChannel {
+            get {
+                return ResourceManager.GetString("UseCustomChatChannel", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to Verified.
         /// </summary>

--- a/PlayerTrack.Plugin/Resource/Language.resx
+++ b/PlayerTrack.Plugin/Resource/Language.resx
@@ -114,6 +114,12 @@
     <data name="CategorySpecificSetting" xml:space="preserve">
         <value>Inherited from the category {0}</value>
     </data>
+    <data name="Chat" xml:space="preserve">
+        <value>Chat</value>
+    </data>
+    <data name="ChatChannel" xml:space="preserve">
+        <value>Chat Channel</value>
+    </data>
     <data name="ClosePlayer" xml:space="preserve">
         <value>Close Player</value>
     </data>
@@ -863,6 +869,9 @@
     </data>
     <data name="Upgrade" xml:space="preserve">
         <value>Upgrade</value>
+    </data>
+    <data name="UseCustomChatChannel" xml:space="preserve">
+        <value>Use Custom Chat Channel</value>
     </data>
     <data name="Verified" xml:space="preserve">
         <value>Verified</value>

--- a/PlayerTrack.Plugin/Windows/Config/Components/IntegrationComponent.cs
+++ b/PlayerTrack.Plugin/Windows/Config/Components/IntegrationComponent.cs
@@ -1,4 +1,5 @@
-﻿using Dalamud.Interface.Utility;
+﻿using Dalamud.Game.Text;
+using Dalamud.Interface.Utility;
 using Dalamud.Interface.Utility.Raii;
 using Dalamud.Bindings.ImGui;
 using PlayerTrack.Domain;
@@ -8,6 +9,45 @@ namespace PlayerTrack.Windows.Config.Components;
 
 public class IntegrationComponent : ConfigViewComponent
 {
+    private static readonly XivChatType[] ChatChannels =
+    {
+        XivChatType.Notice,
+        XivChatType.Echo,
+        XivChatType.Debug,
+        XivChatType.Urgent,
+        XivChatType.SystemMessage,
+        XivChatType.SystemError,
+        XivChatType.ErrorMessage,
+        XivChatType.GatheringSystemMessage,
+        XivChatType.Say,
+        XivChatType.Yell,
+        XivChatType.Shout,
+        XivChatType.TellIncoming,
+        XivChatType.TellOutgoing,
+        XivChatType.Party,
+        XivChatType.CrossParty,
+        XivChatType.Alliance,
+        XivChatType.FreeCompany,
+        XivChatType.NoviceNetwork,
+        XivChatType.PvPTeam,
+        XivChatType.Ls1,
+        XivChatType.Ls2,
+        XivChatType.Ls3,
+        XivChatType.Ls4,
+        XivChatType.Ls5,
+        XivChatType.Ls6,
+        XivChatType.Ls7,
+        XivChatType.Ls8,
+        XivChatType.CrossLinkShell1,
+        XivChatType.CrossLinkShell2,
+        XivChatType.CrossLinkShell3,
+        XivChatType.CrossLinkShell4,
+        XivChatType.CrossLinkShell5,
+        XivChatType.CrossLinkShell6,
+        XivChatType.CrossLinkShell7,
+        XivChatType.CrossLinkShell8,
+    };
+
     public override void Draw()
     {
         using var tabBar = ImRaii.TabBar("###Integration_TabBar", ImGuiTabBarFlags.None);
@@ -24,6 +64,12 @@ public class IntegrationComponent : ConfigViewComponent
         {
             if (tabItem.Success)
                 DrawVisibilityTab();
+        }
+
+        using (var tabItem = ImRaii.TabItem(Language.Chat))
+        {
+            if (tabItem.Success)
+                DrawChatTab();
         }
     }
 
@@ -45,6 +91,40 @@ public class IntegrationComponent : ConfigViewComponent
         {
             Config.SyncWithVisibility = syncWithVisibility;
             ServiceContext.ConfigService.SaveConfig(Config);
+        }
+    }
+
+    private void DrawChatTab()
+    {
+        ImGuiHelpers.ScaledDummy(1f);
+        var useCustom = Config.UseCustomChatChannel;
+        if (Helper.Checkbox(Language.UseCustomChatChannel, ref useCustom))
+        {
+            Config.UseCustomChatChannel = useCustom;
+            ServiceContext.ConfigService.SaveConfig(Config);
+        }
+
+        if (!useCustom)
+            return;
+
+        var current = Config.CustomChatChannel;
+        ImGuiHelpers.ScaledDummy(1f);
+        ImGui.SetNextItemWidth(Helper.CalcScaledComboWidth(200));
+        using var combo = ImRaii.Combo(Language.ChatChannel, current.ToString());
+        if (!combo.Success)
+            return;
+
+        foreach (var channel in ChatChannels)
+        {
+            var isSelected = channel == current;
+            if (ImGui.Selectable(channel.ToString(), isSelected))
+            {
+                Config.CustomChatChannel = channel;
+                ServiceContext.ConfigService.SaveConfig(Config);
+            }
+
+            if (isSelected)
+                ImGui.SetItemDefaultFocus();
         }
     }
 }


### PR DESCRIPTION
Adds an option under Settings -> Integrations -> Chat to redirect PlayerTrack's in-game notifications to a chat channel of the user's choice.

- Checkbox off (default) -> unchanged, messages still go to XivChatType.Notice.
- Checkbox on -> dropdown of common channels: Notice, Echo, Debug, Urgent, system messages, Say/Yell/Shout, Tell, Party, Alliance, FC, Novice Network, PvP Team, Linkshells 1–8, CrossLinkShells 1–8.